### PR TITLE
WIP enable use of dataset collection as input

### DIFF
--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -28,15 +28,23 @@
     #set reference_database_name = "silva"
   #end if
 
+  ## Make links to Categories.txt and Metatable.txt
+  ln -s "${categories_file_in}" Categories.txt &&
+  ln -s "${metatable_file_in}" Metatable.txt &&
+
   ## Create links to input FASTQs and Final_names.txt file
   ## NB file names must have .fastq extension and contain
   ## "_R1_" or "_R2_"
   #if str($input_type.pairs_or_collection) == "collection"
+    i=0 &&
     #for $fq_pair in $input_type.fastq_collection
-      ln -s "${fq_pair.forward}" "${fq_pair.name}_R1_.fastq" &&
-      ln -s "${fq_pair.reverse}" "${fq_pair.name}_R2_.fastq" &&
-      echo ${fq_pair.name}_R1_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
-      echo ${fq_pair.name}_R2_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
+      i=\$((i+1)) &&
+      ## Get sample id (=name) directly from Metatable file
+      sample_id=\$(grep -v "^#" Metatable.txt | cut -f1 | paste -s | cut -f\$i) &&
+      ln -s "${fq_pair.forward}" "\${sample_id}_R1_.fastq" &&
+      ln -s "${fq_pair.reverse}" "\${sample_id}_R2_.fastq" &&
+      echo \${sample_id}_R1_.fastq\$'\t'"\${sample_id}" >> Final_name.txt &&
+      echo \${sample_id}_R2_.fastq\$'\t'"\${sample_id}" >> Final_name.txt &&
     #end for
   #else
     #for $fq_pair in $input_type.fastq_pairs
@@ -46,10 +54,6 @@
       echo ${fq_pair.name}_R2_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
     #end for
   #end if
-
-  ## Make links to Categories.txt and Metatable.txt
-  ln -s "${categories_file_in}" Categories.txt &&
-  ln -s "${metatable_file_in}" Metatable.txt &&
 
   ## Run the amplicon analysis pipeline script
   Amplicon_analysis_pipeline.sh

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -117,7 +117,9 @@
       </param>
       <when value="collection">
 	<param name="fastq_collection" type="data_collection"
-	       format="fastqsanger" collection_type="list:paired"/>
+	       format="fastqsanger" collection_type="list:paired"
+	       label="Collection of FASTQ forward and reverse (R1/R2) pairs"
+	       help="Each FASTQ pair will be treated as one sample; the name of each sample will be taken from the first column of the Metatable file " />
       </when>
       <when value="pairs_of_files">
 	<repeat name="fastq_pairs" title="Input fastq pairs" min="1">

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -31,12 +31,21 @@
   ## Create links to input FASTQs and Final_names.txt file
   ## NB file names must have .fastq extension and contain
   ## "_R1_" or "_R2_"
-  #for $fq_pair in $fastq_pairs
-    ln -s "${fq_pair.fastq_r1}" "${fq_pair.name}_R1_.fastq" &&
-    ln -s "${fq_pair.fastq_r2}" "${fq_pair.name}_R2_.fastq" &&
-    echo ${fq_pair.name}_R1_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
-    echo ${fq_pair.name}_R2_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
-  #end for
+  #if str($input_type.pairs_or_collection) == "collection"
+    #for $fq_pair in $input_type.fastq_collection
+      ln -s "${fq_pair.forward}" "${fq_pair.name}_R1_.fastq" &&
+      ln -s "${fq_pair.reverse}" "${fq_pair.name}_R2_.fastq" &&
+      echo ${fq_pair.name}_R1_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
+      echo ${fq_pair.name}_R2_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
+    #end for
+  #else
+    #for $fq_pair in $input_type.fastq_pairs
+      ln -s "${fq_pair.fastq_r1}" "${fq_pair.name}_R1_.fastq" &&
+      ln -s "${fq_pair.fastq_r2}" "${fq_pair.name}_R2_.fastq" &&
+      echo ${fq_pair.name}_R1_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
+      echo ${fq_pair.name}_R2_.fastq\$'\t'"${fq_pair.name}" >> Final_name.txt &&
+    #end for
+  #end if
 
   ## Make links to Categories.txt and Metatable.txt
   ln -s "${categories_file_in}" Categories.txt &&
@@ -96,14 +105,27 @@
 	   label="Input Metatable.txt file" />
     <param type="data" name="categories_file_in" format="tabular"
 	   label="Input Categories.txt file" />
-    <repeat name="fastq_pairs" title="Input fastq pairs" min="1">
-      <param type="text" name="name" value=""
-	     label="Final name for FASTQ pair" />
-      <param type="data" name="fastq_r1" format="fastqsanger"
-	     label="FASTQ with forward reads (R1)" />
-      <param type="data" name="fastq_r2" format="fastqsanger"
-	     label="FASTQ with reverse reads (R2)" />
-    </repeat>
+    <conditional name="input_type">
+      <param name="pairs_or_collection" type="select"
+	     label="Input FASTQ type">
+	<option value="pairs_of_files" selected="true">Pairs of datasets</option>
+	<option value="collection">Dataset pairs in a collection</option>
+      </param>
+      <when value="collection">
+	<param name="fastq_collection" type="data_collection"
+	       format="fastqsanger" collection_type="list:paired"/>
+      </when>
+      <when value="pairs_of_files">
+	<repeat name="fastq_pairs" title="Input fastq pairs" min="1">
+	  <param type="text" name="name" value=""
+		 label="Final name for FASTQ pair" />
+	  <param type="data" name="fastq_r1" format="fastqsanger"
+		 label="FASTQ with forward reads (R1)" />
+	  <param type="data" name="fastq_r2" format="fastqsanger"
+		 label="FASTQ with reverse reads (R2)" />
+	</repeat>
+      </when>
+    </conditional>
     <param type="text" name="forward_pcr_primer" value=""
 	   label="Forward PCR primer sequence"
 	   help="Must not include barcode or adapter sequence (-g)" />

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -41,10 +41,10 @@
       i=\$((i+1)) &&
       ## Get sample id (=name) directly from Metatable file
       sample_id=\$(grep -v "^#" Metatable.txt | cut -f1 | paste -s | cut -f\$i) &&
-      ln -s "${fq_pair.forward}" "\${sample_id}_R1_.fastq" &&
-      ln -s "${fq_pair.reverse}" "\${sample_id}_R2_.fastq" &&
-      echo \${sample_id}_R1_.fastq\$'\t'"\${sample_id}" >> Final_name.txt &&
-      echo \${sample_id}_R2_.fastq\$'\t'"\${sample_id}" >> Final_name.txt &&
+      ln -s "${fq_pair.forward}" "${fq_pair.name}_R1_.fastq" &&
+      ln -s "${fq_pair.reverse}" "${fq_pair.name}_R2_.fastq" &&
+      echo ${fq_pair.name}_R1_.fastq\$'\t'"\${sample_id}" >> Final_name.txt &&
+      echo ${fq_pair.name}_R2_.fastq\$'\t'"\${sample_id}" >> Final_name.txt &&
     #end for
   #else
     #for $fq_pair in $input_type.fastq_pairs


### PR DESCRIPTION
This PR is intended to address issue #3, by enabling the use of a dataset collection consisting of a list of FASTQ R1/R2 pairs as input to the tool (as an alternative to specifying each FASTQ input dataset manually).