### PR TITLE
Fix installer script for 'fasta_number' (was broken)

### DIFF
--- a/install_tool_deps.sh
+++ b/install_tool_deps.sh
@@ -509,10 +509,12 @@ function install_fasta_number() {
     if [ -f $install_dir/env.sh ] ; then
 	return
     fi
-    # Install script and make 'default' link
+    # Install scripts and make 'default' link
     mkdir -p $install_dir/bin
+    mkdir -p $install_dir/lib
     tar zxf python_scripts.tar.gz
     mv fasta_number.py $install_dir/bin
+    mv die.py $install_dir/lib
     ln -s $version $default_dir
     popd
     # Clean up
@@ -524,6 +526,7 @@ cat > $install_dir/env.sh <<EOF
 # Source this to setup fasta_number/$version
 echo Setting up fasta_number $version
 export PATH=$install_dir/bin:\$PATH
+export PYTHONPATH=$install_dir/lib:\$PYTHONPATH
 #
 EOF
 }


### PR DESCRIPTION
PR to fixes the problem with `fasta_number` reported in issue #9, by including the missing `die.py` file when installing the program.