### PR TITLE
WIP Galaxy tool to relabel samples in a "list-of-pairs" dataset collection

### DIFF
--- a/relabel_samples.xml
+++ b/relabel_samples.xml
@@ -1,0 +1,45 @@
+<tool id="relabel_samples" name="Relabel samples in collection" version="0.1.0">
+  <description>for input into Amplicon Analysis Pipeline</description>
+  <command><![CDATA[
+  i=0 &&
+  #for $fq_pair in $fastqs_in
+    i=\$((i+1)) &&
+    sample_id=\$(grep -v "^#" $new_labels | cut -f1 | paste -s | cut -f\$i) &&
+    cp "${fq_pair.forward}" \${sample_id}_forward.fastq &&
+    cp "${fq_pair.reverse}" \${sample_id}_reverse.fastq &&
+  #end for
+  echo
+  ]]></command>
+  <inputs>
+    <param name="fastqs_in" type="data_collection"
+	   format="fastqsanger" collection_type="list:paired"
+	   label="Collection of FASTQ forward and reverse (R1/R2) pairs" />
+    <param name="new_labels" type="data" format="text"
+	   label="List of new labels" />
+  </inputs>
+  <outputs>
+    <collection name="fastqs_out" type="list:paired"
+		label="${fastqs_in.name} (relabeled)">
+      <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_(?P&lt;identifier_1&gt;[^_]+)\.fastq" ext="fastqsanger" visible="true" />
+    </collection>
+  </outputs>
+  <help><![CDATA[
+.. class:: infomark
+
+**What it does**
+
+This tool creates a new dataset collection from an existing list
+of paired FASTQ files, with new labels for each pair taken from
+the supplied list.
+
+**Usage**
+
+TBA
+
+**Authors**
+
+Peter Briggs
+
+  ]]></help>
+</tool>
+

--- a/relabel_samples.xml
+++ b/relabel_samples.xml
@@ -11,6 +11,9 @@
   echo
   ]]></command>
   <inputs>
+    <param name="new_collection_name" type="text"
+	   value="Relabelled collection"
+	   label="Name for relabelled collection" />
     <param name="fastqs_in" type="data_collection"
 	   format="fastqsanger" collection_type="list:paired"
 	   label="Collection of FASTQ forward and reverse (R1/R2) pairs" />
@@ -19,7 +22,7 @@
   </inputs>
   <outputs>
     <collection name="fastqs_out" type="list:paired"
-		label="${fastqs_in.name} (relabeled)">
+		label="${new_collection_name}">
       <discover_datasets pattern="(?P&lt;identifier_0&gt;.+)_(?P&lt;identifier_1&gt;[^_]+)\.fastq" ext="fastqsanger" visible="true" />
     </collection>
   </outputs>
@@ -34,7 +37,19 @@ the supplied list.
 
 **Usage**
 
-TBA
+The tool requires an appropriate dataset collection plus a text file
+consisting of new names to use as labels (one per line).
+
+There must be as many new labels as FASTQ pairs in the collection;
+new labels are applied in the order that they appear in the file.
+
+.. class:: warningmark
+
+This tool has lots of issues, the principal of which is that in
+order to create the new collection it also creates new FASTQ pairs
+which duplicate those from the original collection. This makes it
+slow, and the outputs also consume additional quota space to the
+size of the input collection.
 
 **Authors**
 


### PR DESCRIPTION
PR that attempts to address issue #18. The `relabel_samples` tool takes a dataset collection (a list of paired FASTQs ) as input along with a list of sample names, and creates a new collection with the same pairs but relabelled using the names from the list.

There are some issues with the initial version:

 * Duplicates the datasets from the input collection unnecessarily (and also eats up disk space/user quota)
 * No sanity checking that number of pairs matches the number of supplied names
 * No way to specify the original name to be relabelled