### PR TITLE
WIP clean up sample names from Fastq collection pairs

### DIFF
--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -58,6 +58,20 @@ def print_error(message):
         sys.stderr.write("* %s%s *\n" % (line,' '*(width-len(line)-4)))
     sys.stderr.write("%s\n\n" % ('*'*width))
 
+def clean_up_name(sample):
+    # Remove trailing "_L[0-9]+_001" from Fastq
+    # pair names
+    split_name = sample.split('_')
+    if split_name[-1] == "001":
+        split_name = split_name[:-1]
+    if split_name[-1].startswith('L'):
+        try:
+            int(split_name[-1][1:])
+            split_name = split_name[:-1]
+        except ValueError:
+            pass
+    return '_'.join(split_name)
+
 if __name__ == "__main__":
     # Command line
     print "Amplicon analysis: starting"
@@ -99,6 +113,7 @@ if __name__ == "__main__":
     with open("Final_name.txt",'w') as final_name:
         fastqs = iter(args.fastq_pairs)
         for sample_name,fqr1,fqr2 in zip(fastqs,fastqs,fastqs):
+            sample_name = clean_up_name(sample_name)
             r1 = "%s_R1_.fastq" % sample_name
             r2 = "%s_R2_.fastq" % sample_name
             os.symlink(fqr1,r1)


### PR DESCRIPTION
PR to address issue #29: attempt to clean up the sample names associated with pairs of Fastqs in a collection, if the source names were 'canonical' Fastqs.