### PR TITLE
List output files in the tool stdout

### DIFF
--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -103,5 +103,13 @@ if __name__ == "__main__":
         sys.stderr.write("ERROR missing log file \"%s\"\n" %
                          log_file)
 
+    # List the output directory contents
+    sys.stdout.write("\nOutput files:\n")
+    results_dir = os.path.abspath("RESULTS")
+    for d,dirs,files in os.walk(results_dir):
+        sys.stdout.write("-- %s\n" % os.path.relpath(d,results_dir))
+        for f in files:
+            sys.stdout.write("---- %s\n" % os.path.relpath(f,results_dir))
+
     # Finish
     sys.exit(exit_code)


### PR DESCRIPTION
PR to generate a list of the 'raw' output files in the tool stdout (which can be accessed via the info "i" button in an expanded Galaxy dataset). This will hopefully make it easier to identify additional outputs that need to be captured in future.

One problem encountered in making this change was that including the unmodified stdout from the script seemed to result in a garbled log file. These outputs should therefore be made available in an alternative fashion.