### PR TITLE
Collect additional outputs when Categories file is supplied

### DIFF
--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -252,7 +252,7 @@ if __name__ == "__main__":
                          "Alpha_diversity",
                          "Alpha_diversity_boxplot",
                          "Categories_shannon"))
-        print "Amplicon analysis: gathering PDFS from %s" % boxplots_dir
+        print "Amplicon analysis: gathering PDFs from %s" % boxplots_dir
         boxplot_pdfs = [os.path.basename(pdf)
                         for pdf in
                         sorted(glob.glob(

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -7,6 +7,7 @@ import sys
 import os
 import argparse
 import subprocess
+import glob
 
 class PipelineCmd(object):
     def __init__(self,cmd):
@@ -241,20 +242,34 @@ if __name__ == "__main__":
 
     # Handle additional output when categories file was supplied
     if args.categories_file is not None:
-        with open("categories_data.html","w") as categories_out:
-            categories_out.write("""<html>
+        # Alpha diversity boxplots
+        print "Amplicon analysis: indexing alpha diversity boxplots"
+        boxplots_dir = os.path.abspath(
+            os.path.join("RESULTS",
+                         "%s_%s" % (args.pipeline.title(),
+                                    ("gg" if not args.use_silva
+                                     else "silva")),
+                         "Alpha_diversity",
+                         "Alpha_diversity_boxplot",
+                         "Categories_shannon"))
+        print "Amplicon analysis: gathering PDFS from %s" % boxplots_dir
+        boxplot_pdfs = [os.path.basename(pdf)
+                        for pdf in
+                        sorted(glob.glob(
+                            os.path.join(boxplots_dir,"*.pdf")))]
+        with open("alpha_diversity_boxplots.html","w") as boxplots_out:
+            boxplots_out.write("""<html>
 <head>
-<title>Amplicon analysis pipeline: Categories</title>
+<title>Amplicon analysis pipeline: Alpha Diversity Boxplots (Shannon)</title>
 <head>
 <body>
-<h1>Amplicon analysis pipeline: Categories</h1>
+<h1>Amplicon analysis pipeline: Alpha Diversity Boxplots (Shannon)</h1>
 """)
-            categories_out.write("<h2>Rarefaction curves</h2>\n")
-            categories_out.write("<ul>\n")
-            categories_out.write("<li>%s</li>\n" %
-                                 ahref("rarefaction_plots.html"))
-            categories_out.write("<ul>\n")
-            categories_out.write("""</body>
+            boxplots_out.write("<ul>\n")
+            for pdf in boxplot_pdfs:
+                boxplots_out.write("<li>%s</li>\n" % ahref(pdf))
+            boxplots_out.write("<ul>\n")
+            boxplots_out.write("""</body>
 </html>
 """)
 

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -239,6 +239,25 @@ if __name__ == "__main__":
         sys.stderr.write("ERROR missing log file \"%s\"\n" %
                          log_file)
 
+    # Handle additional output when categories file was supplied
+    if args.categories_file is not None:
+        with open("categories_data.html","w") as categories_out:
+            categories_out.write("""<html>
+<head>
+<title>Amplicon analysis pipeline: Categories</title>
+<head>
+<body>
+<h1>Amplicon analysis pipeline: Categories</h1>
+""")
+            categories_out.write("<h2>Rarefaction curves</h2>\n")
+            categories_out.write("<ul>\n")
+            categories_out.write("<li>%s</li>\n" %
+                                 ahref("rarefaction_plots.html"))
+            categories_out.write("<ul>\n")
+            categories_out.write("""</body>
+</html>
+""")
+
     # Finish
     print "Amplicon analysis: finishing, exit code: %s" % exit_code
     sys.exit(exit_code)

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -72,6 +72,29 @@ def clean_up_name(sample):
             pass
     return '_'.join(split_name)
 
+def list_outputs(filen=None):
+    # List the output directory contents
+    # If filen is specified then will be the filename to
+    # write to, otherwise write to stdout
+    if filen is not None:
+        fp = open(filen,'w')
+    else:
+        fp = sys.stdout
+    results_dir = os.path.abspath("RESULTS")
+    fp.write("Listing contents of output dir %s:\n" % results_dir)
+    ix = 0
+    for d,dirs,files in os.walk(results_dir):
+        ix += 1
+        fp.write("-- %d: %s\n" % (ix,
+                                  os.path.relpath(d,results_dir)))
+        for f in files:
+            ix += 1
+            fp.write("---- %d: %s\n" % (ix,
+                                        os.path.relpath(f,results_dir)))
+    # Close output file
+    if filen is not None:
+        fp.close()
+
 if __name__ == "__main__":
     # Command line
     print "Amplicon analysis: starting"
@@ -103,11 +126,13 @@ if __name__ == "__main__":
     print "Amplicon analysis: building the environment"
     metatable_file = os.path.abspath(args.metatable)
     os.symlink(metatable_file,"Metatable.txt")
+    print "-- made symlink to Metatable.txt"
 
     # Link to Categories.txt file (if provided)
     if args.categories_file is not None:
         categories_file = os.path.abspath(args.categories_file)
         os.symlink(categories_file,"Categories.txt")
+        print "-- made symlink to Categories.txt"
 
     # Link to FASTQs and construct Final_name.txt file
     with open("Final_name.txt",'w') as final_name:
@@ -160,6 +185,10 @@ if __name__ == "__main__":
             # Some other problem
             sys.stderr.write("Unexpected error: %s\n" % str(ex))
 
+    # Write out the list of outputs
+    outputs_file = "Pipeline_outputs.txt"
+    list_outputs(outputs_file)
+
     # Check for log file
     log_file = "Amplicon_analysis_pipeline.log"
     if os.path.exists(log_file):
@@ -186,6 +215,10 @@ if __name__ == "__main__":
                     ahref("pipeline.log",type="text/plain"))
                 html_out.write(
                     "<li>%s</li>\n" %
+                    ahref("Pipeline_outputs.txt",
+                          type="text/plain"))
+                html_out.write(
+                    "<li>%s</li>\n" %
                     ahref("Metatable.html"))
                 html_out.write("""<ul>
 </body>
@@ -205,14 +238,6 @@ if __name__ == "__main__":
     else:
         sys.stderr.write("ERROR missing log file \"%s\"\n" %
                          log_file)
-
-    # List the output directory contents
-    results_dir = os.path.abspath("RESULTS")
-    print "Listing contents of output dir %s:" % results_dir
-    for d,dirs,files in os.walk(results_dir):
-        print "-- %s" % os.path.relpath(d,results_dir)
-        for f in files:
-            print "---- %s" % os.path.relpath(f,results_dir)
 
     # Finish
     print "Amplicon analysis: finishing, exit code: %s" % exit_code

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -51,7 +51,7 @@
   #if str( $reference_database ) != ""
     "${reference_database}"
   #end if
-  #if str( $categories_file_in ) != ""
+  #if $categories_file_in is not None
     -c "${categories_file_in}"
   #end if
   ## Input files
@@ -100,12 +100,12 @@
   cp RESULTS/${pipeline}_${reference_database_name}/beta_div_even/unweighted_2d_plot/unweighted_unifrac_pc_2D_PCoA_plots.html "${beta_div_even_unweighted_2d_plots}" &&
 
   ## Categories data
-  #if str( $categories_file_in ) != ""
-    # Alpha diversity rarefaction plots
+  #if $categories_file_in is not None
+    ## Alpha diversity rarefaction plots
     mkdir $alpha_div_rarefaction_plots.files_path &&
     cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/rarefaction_plots.html $alpha_div_rarefaction_plots &&
     cp -r RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/average_plots $alpha_div_rarefaction_plots.files_path &&
-    # Alpha diversity boxplots
+    ## Alpha diversity boxplots
     mkdir $alpha_div_boxplots.files_path &&
     cp alpha_diversity_boxplots.html "$alpha_div_boxplots" &&
     cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/Alpha_diversity_boxplot/Categories_shannon/*.pdf $alpha_div_boxplots.files_path &&

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -104,7 +104,7 @@
     mkdir $categories_out.files_path &&
     cp categories_data.html "$categories_out" &&
     cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/rarefaction_plots.html $categories_out.files_path &&
-    cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/average_plots/* $categories_out.files_path &&
+    cp -r RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/average_plots $categories_out.files_path &&
   #end if
 
   ## Pipeline outputs (log files etc)
@@ -201,7 +201,7 @@
 	  label="${tool.name} (${pipeline}):${title} beta diversity unweighted 2D plots HTML" />
     <data format="html" name="categories_out"
 	  label="${tool.name} (${pipeline}):${title} categories data">
-      <filter>str( $categories_file_in ) != ""</filter>
+      <filter>categories_file_in != ""</filter>
     </data>
     <data format="html" name="log_files"
 	  label="${tool.name} (${pipeline}):${title} log files" />

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -99,10 +99,19 @@
   cp -r RESULTS/${pipeline}_${reference_database_name}/beta_div_even/unweighted_2d_plot/* $beta_div_even_unweighted_2d_plots.files_path &&
   cp RESULTS/${pipeline}_${reference_database_name}/beta_div_even/unweighted_2d_plot/unweighted_unifrac_pc_2D_PCoA_plots.html "${beta_div_even_unweighted_2d_plots}" &&
 
+  ## Categories data
+  #if str( $categories_file_in ) != ""
+    mkdir $categories_out.files_path &&
+    cp categories_data.html "$categories_out" &&
+    cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/rarefaction_plots.html $categories_out.files_path &&
+    cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/average_plots/* $categories_out.files_path &&
+  #end if
+
   ## Pipeline outputs (log files etc)
   mkdir $log_files.files_path &&
   cp Amplicon_analysis_pipeline.log $log_files.files_path &&
   cp pipeline.log $log_files.files_path &&
+  cp Pipeline_outputs.txt $log_files.files_path &&
   cp Metatable_log/Metatable.html $log_files.files_path &&
   cp pipeline_outputs.html "$log_files"
   ]]></command>
@@ -190,6 +199,10 @@
 	  label="${tool.name} (${pipeline}):${title} beta diversity weighted 2D plots HTML" />
     <data format="html" name="beta_div_even_unweighted_2d_plots"
 	  label="${tool.name} (${pipeline}):${title} beta diversity unweighted 2D plots HTML" />
+    <data format="html" name="categories_out"
+	  label="${tool.name} (${pipeline}):${title} categories data">
+      <filter>str( $categories_file_in ) != ""</filter>
+    </data>
     <data format="html" name="log_files"
 	  label="${tool.name} (${pipeline}):${title} log files" />
   </outputs>

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -101,10 +101,14 @@
 
   ## Categories data
   #if str( $categories_file_in ) != ""
-    mkdir $categories_out.files_path &&
-    cp categories_data.html "$categories_out" &&
-    cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/rarefaction_plots.html $categories_out.files_path &&
-    cp -r RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/average_plots $categories_out.files_path &&
+    # Alpha diversity rarefaction plots
+    mkdir $alpha_div_rarefaction_plots.files_path &&
+    cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/rarefaction_plots.html $alpha_div_rarefaction_plots &&
+    cp -r RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/rarefaction_curves/average_plots $alpha_div_rarefaction_plots.files_path &&
+    # Alpha diversity boxplots
+    mkdir $alpha_div_boxplots.files_path &&
+    cp alpha_diversity_boxplots.html "$alpha_div_boxplots" &&
+    cp RESULTS/${pipeline}_${reference_database_name}/Alpha_diversity/Alpha_diversity_boxplot/Categories_shannon/*.pdf $alpha_div_boxplots.files_path &&
   #end if
 
   ## Pipeline outputs (log files etc)
@@ -199,8 +203,12 @@
 	  label="${tool.name} (${pipeline}):${title} beta diversity weighted 2D plots HTML" />
     <data format="html" name="beta_div_even_unweighted_2d_plots"
 	  label="${tool.name} (${pipeline}):${title} beta diversity unweighted 2D plots HTML" />
-    <data format="html" name="categories_out"
-	  label="${tool.name} (${pipeline}):${title} categories data">
+    <data format="html" name="alpha_div_rarefaction_plots"
+	  label="${tool.name} (${pipeline}):${title} alpha diversity rarefaction plots HTML">
+      <filter>categories_file_in is not None</filter>
+    </data>
+    <data format="html" name="alpha_div_boxplots"
+	  label="${tool.name} (${pipeline}):${title} alpha diversity boxplots">
       <filter>categories_file_in is not None</filter>
     </data>
     <data format="html" name="log_files"

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -201,7 +201,7 @@
 	  label="${tool.name} (${pipeline}):${title} beta diversity unweighted 2D plots HTML" />
     <data format="html" name="categories_out"
 	  label="${tool.name} (${pipeline}):${title} categories data">
-      <filter>categories_file_in != ""</filter>
+      <filter>categories_file_in is not None</filter>
     </data>
     <data format="html" name="log_files"
 	  label="${tool.name} (${pipeline}):${title} log files" />


### PR DESCRIPTION
PR to address issue #28 and collect additional files that are produced if a `Categories` file is supplied to the tool by the user.