### PR TITLE
Enable the pipeline -l option (sliding window length) to be set in the Galaxy tool

### DIFF
--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -114,6 +114,7 @@ if __name__ == "__main__":
     p.add_argument("-q",dest="trimming_threshold")
     p.add_argument("-O",dest="minimum_overlap")
     p.add_argument("-L",dest="minimum_length")
+    p.add_argument("-l",dest="sliding_window_length")
     p.add_argument("-P",dest="pipeline",
                    choices=["vsearch","uparse","qiime"],
                    type=str.lower,
@@ -160,6 +161,8 @@ if __name__ == "__main__":
         pipeline.add_args("-O",args.minimum_overlap)
     if args.minimum_length:
         pipeline.add_args("-L",args.minimum_length)
+    if args.sliding_window_length:
+        pipeline.add_args("-l",args.sliding_window_length)
     if args.reference_data_path:
         pipeline.add_args("-r",args.reference_data_path)
     pipeline.add_args("-P",args.pipeline)

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -40,6 +40,9 @@
   #if str( $trimming_threshold ) != ""
   -q $trimming_threshold
   #end if
+  #if str( $sliding_window_length ) != ""
+  -l $sliding_window_length
+  #end if
   #if str( $minimum_overlap ) != ""
   -O $minimum_overlap
   #end if
@@ -166,6 +169,9 @@
     <param type="integer" name="minimum_length" value="200"
 	   label="Minimum length in bp to keep sequence after overlapping"
 	   help="Default is 200 (-L)" />
+    <param type="integer" name="sliding_window_length" value="10"
+	   label="Length of the sliding window in bp"
+	   help="Supplied to Sickle; default is 10 (-l)" />
     <param type="select" name="pipeline"
 	    label="Pipeline to use for analysis">
       <option value="Vsearch" selected="true" >Vsearch</option>


### PR DESCRIPTION
PR that adds support for the `-l` option of the pipeline script (sets length of the sliding window used by `sickle`).