### PR TITLE
Clean up sample names from the input Metatable.txt file

### DIFF
--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -164,6 +164,7 @@ if __name__ == "__main__":
             sample_names.append(sample_name)
 
     # Check the sample names
+    sample_names_error = False
     for sample_name in metatable_sample_names:
         if sample_name not in metatable_sample_names:
             sys.stderr.write("WARNING Sample name '%s' in "

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
     with open(args.metatable,'r') as metatable_in:
         with open(metatable_file,'w') as metatable_out:
             for line in metatable_in:
-                if line.startswith('#') and metatable_header is None:
+                if line.startswith('#') is None:
                     metatable_out.write(line)
                     continue
                 data = line.split('\t')
@@ -169,7 +169,7 @@ if __name__ == "__main__":
         sample_names_error = True
     else:
         for sample_name in sample_names:
-            if sample_name not in sample_names_metatable:
+            if sample_name not in metatable_sample_names:
                 sys.stderr.write("WARNING Sample name '%s' not in "
                                  "Metatable\n" % sample_name)
                 sample_names_error = True

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -138,7 +138,9 @@ if __name__ == "__main__":
                     continue
                 data = line.split('\t')
                 sample_name = clean_up_name(data[0])
-                data[0] = sample_name
+                if sample_name != data[0]:
+                    print "%s -> %s" % (data[0],sample_name)
+                    data[0] = sample_name
                 metatable_out.write('\t'.join(data))
                 metatable_sample_names.append(sample_name)
     print "-- constructed local Metatable.txt file"
@@ -166,7 +168,7 @@ if __name__ == "__main__":
     # Check the sample names
     sample_names_error = False
     for sample_name in metatable_sample_names:
-        if sample_name not in metatable_sample_names:
+        if sample_name not in sample_names:
             sys.stderr.write("WARNING Sample name '%s' in "
                              "updated metatable not found "
                              "in list of Fastq pairs\n" %

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
     with open(args.metatable,'r') as metatable_in:
         with open(metatable_file,'w') as metatable_out:
             for line in metatable_in:
-                if line.startswith('#') is None:
+                if line.startswith('#'):
                     metatable_out.write(line)
                     continue
                 data = line.split('\t')

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -177,9 +177,8 @@ if __name__ == "__main__":
         else:
             print "Sample name '%s' ok" % sample_name
     if sample_names_error:
-        sys.stderr.write("ERROR Sample names from Fastqs don't "
+        sys.stderr.write("WARNING Sample names from Fastqs don't "
                          "match those in Metatable\n")
-        sys.exit(1)
 
     # Construct the pipeline command
     print "Amplicon analysis: constructing pipeline command"

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -164,17 +164,15 @@ if __name__ == "__main__":
             sample_names.append(sample_name)
 
     # Check the sample names
-    sample_names_error = False
-    if len(sample_names) != len(metatable_sample_names):
-        sample_names_error = True
-    else:
-        for sample_name in sample_names:
-            if sample_name not in metatable_sample_names:
-                sys.stderr.write("WARNING Sample name '%s' not in "
-                                 "Metatable\n" % sample_name)
-                sample_names_error = True
-            else:
-                print "Sample name '%s' ok" % sample_name
+    for sample_name in metatable_sample_names:
+        if sample_name not in metatable_sample_names:
+            sys.stderr.write("WARNING Sample name '%s' in "
+                             "updated metatable not found "
+                             "in list of Fastq pairs\n" %
+                             sample_name)
+            sample_names_error = True
+        else:
+            print "Sample name '%s' ok" % sample_name
     if sample_names_error:
         sys.stderr.write("ERROR Sample names from Fastqs don't "
                          "match those in Metatable\n")


### PR DESCRIPTION
PR to clean up the sample names from the input `Metatable.txt` file, by removing any trailing `L*_001` parts of the name (as is already done for the Fastq pair names).