### PR TITLE
Explicitly set an exit code when an 'unexpected error' is encountered

### DIFF
--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -190,6 +190,7 @@ if __name__ == "__main__":
         except Exception as ex:
             # Some other problem
             sys.stderr.write("Unexpected error: %s\n" % str(ex))
+            exit_code = 1
 
     # Write out the list of outputs
     outputs_file = "Pipeline_outputs.txt"


### PR DESCRIPTION
PR which fixes a bug when an "unexpected error" is encountered (e.g. if the `Amplicon_analysis_pipeline.sh` script is not on the path because the dependency is missing).