### PR TITLE
Update to Amplicon_analysis_pipeline 1.2.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,8 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+1.2.2.0    Updated to Amplicon_Analysis_Pipeline version 1.2.2 (removes
+           jackknifed analysis which is not captured by Galaxy tool)
 1.2.1.0    Updated to Amplicon_Analysis_Pipeline version 1.2.1 (adds
            option to use the Human Oral Microbiome Database v15.1, and
            updates SILVA database to v123)

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -1,7 +1,7 @@
-<tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.1.0">
+<tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.2.0">
   <description>analyse 16S rRNA data from Illumina Miseq paired-end reads</description>
   <requirements>
-    <requirement type="package" version="1.2.1">amplicon_analysis_pipeline</requirement>
+    <requirement type="package" version="1.2.2">amplicon_analysis_pipeline</requirement>
     <requirement type="package" version="1.11">cutadapt</requirement>
     <requirement type="package" version="1.33">sickle</requirement>
     <requirement type="package" version="27-08-2013">bioawk</requirement>

--- a/install_tool_deps.sh
+++ b/install_tool_deps.sh
@@ -35,6 +35,9 @@ EOF
     rm -rf $wd/*
     rmdir $wd
 }
+function install_amplicon_analysis_pipeline_1_2_2() {
+    install_amplicon_analysis_pipeline $1 1.2.2
+}
 function install_amplicon_analysis_pipeline_1_2_1() {
     install_amplicon_analysis_pipeline $1 1.2.1
 }
@@ -689,7 +692,7 @@ if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
 # Install dependencies
-install_amplicon_analysis_pipeline_1_2_1 $TOP_DIR
+install_amplicon_analysis_pipeline_1_2_2 $TOP_DIR
 install_cutadapt_1_11 $TOP_DIR
 install_sickle_1_33 $TOP_DIR
 install_bioawk_27_08_2013 $TOP_DIR


### PR DESCRIPTION
PR which updates the tool to use `Amplicon_analysis_pipeline` version 1.2.2.