### PR TITLE
[WIP] migrate tool dependencies to conda

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,47 +178,6 @@ Known problems
    https://github.com/galaxyproject/galaxy/issues/4490 and
    https://github.com/galaxyproject/galaxy/issues/1676
 
-Appendix: availability of tool dependencies
-===========================================
-
-The tool takes its dependencies from the underlying pipeline script (see
-https://github.com/MTutino/Amplicon_analysis/blob/master/README.md
-for details).
-
-As noted above, currently the ``install_amplicon_analysis.sh`` script
-can be used to manually install the dependencies for a local tool
-install.
-
-In principle these should also be available if the tool were installed
-from a toolshed. However it would be preferrable in this case to get as
-many of the dependencies as possible via the ``conda`` dependency
-resolver.
-
-The following are known to be available via conda, with the required
-version:
-
- - cutadapt 1.8.1
- - sickle-trim 1.33
- - bioawk 1.0
- - fastqc 0.11.3
- - R 3.2.0
- - spades 3.5.0
- - qiime 1.8.0
- - blast-legacy 2.2.26
- - vsearch 1.1.3
- - fasta-splitter 0.2.4
- - rdp_classifier 2.2
-
-The following dependencies are currently unavailable:
-
- - R 3.2.1 (installed from the toolshed as the bioconda version
-   has conflicts )
- - microbiomeutil (need r20110519)
-
-
-(NB usearch 6.1.544 and 8.0.1623 are special cases which must be
-handled outside of Galaxy's dependency management systems.)
-
 History
 =======
 
@@ -226,7 +185,7 @@ History
 Version    Changes
 ---------- ----------------------------------------------------------------------
 1.2.3.0    Updated to Amplicon_Analysis_Pipeline version 1.2.3; install
-           dependencies from bioconda and via tool_dependencies.xml
+           dependencies from bioconda and via tool_dependencies.xml.
 1.2.2.0    Updated to Amplicon_Analysis_Pipeline version 1.2.2 (removes
            jackknifed analysis which is not captured by Galaxy tool)
 1.2.1.0    Updated to Amplicon_Analysis_Pipeline version 1.2.1 (adds

--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,12 @@ at run time.
 1. Install the dependencies
 ---------------------------
 
-The ``install_amplicon_analysis.sh`` script can be used to fetch
-and install the dependencies locally, for example::
+If the tool is installed from the Galaxy toolshed (recommended) then
+the dependencies should be installed automatically and this step can
+be skipped.
+
+Otherwise the ``install_amplicon_analysis_deps.sh`` script can be used
+to fetch and install the dependencies locally, for example::
 
     install_amplicon_analysis.sh /path/to/local_tool_dependencies
 
@@ -207,8 +211,10 @@ version:
 
 The following dependencies are currently unavailable:
 
- - fasta_number (need 02jun2015)
+ - R 3.2.1 (installed from the toolshed as the bioconda version
+   has conflicts )
  - microbiomeutil (need r20110519)
+
 
 (NB usearch 6.1.544 and 8.0.1623 are special cases which must be
 handled outside of Galaxy's dependency management systems.)
@@ -219,7 +225,8 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
-1.2.2.1    Update to get dependencies from bioconda
+1.2.3.0    Updated to Amplicon_Analysis_Pipeline version 1.2.3; install
+           dependencies from bioconda and via tool_dependencies.xml
 1.2.2.0    Updated to Amplicon_Analysis_Pipeline version 1.2.2 (removes
            jackknifed analysis which is not captured by Galaxy tool)
 1.2.1.0    Updated to Amplicon_Analysis_Pipeline version 1.2.1 (adds

--- a/README.rst
+++ b/README.rst
@@ -26,27 +26,8 @@ dependencies and reference data, and how to configure the Galaxy
 instance to detect the dependencies and reference data correctly
 at run time.
 
-1. Install the dependencies
----------------------------
-
-If the tool is installed from the Galaxy toolshed (recommended) then
-the dependencies should be installed automatically and this step can
-be skipped.
-
-Otherwise the ``install_amplicon_analysis_deps.sh`` script can be used
-to fetch and install the dependencies locally, for example::
-
-    install_amplicon_analysis.sh /path/to/local_tool_dependencies
-
-This can take some time to complete. When finished it will have
-created a directory called ``Amplicon_analysis-1.2.3`` containing
-the dependencies under the specified top level directory.
-
-**NB** The installed dependencies will occupy around 2.6G of disk
-space.
-
-2. Install the tool files
--------------------------
+1. Install the tool from the toolshed
+-------------------------------------
 
 The core tool is hosted on the Galaxy toolshed, so it can be installed
 directly from there (this is the recommended route):
@@ -65,7 +46,7 @@ file to tell Galaxy to offer the tool by adding the line e.g.::
 
     <tool file="Amplicon_analysis/amplicon_analysis_pipeline.xml" />
 
-3. Install the reference data
+2. Install the reference data
 -----------------------------
 
 The script ``References.sh`` from the pipeline package at
@@ -81,31 +62,12 @@ will install the data in ``/path/to/pipeline/data``.
 **NB** The final amount of data downloaded and uncompressed will be
 around 9GB.
 
-4. Configure dependencies and reference data in Galaxy
-------------------------------------------------------
+3. Configure reference data location in Galaxy
+----------------------------------------------
 
-The final steps are to make your Galaxy installation aware of the
-tool dependencies and reference data, so it can locate them both when
-the tool is run.
-
-To target the tool dependencies installed previously, add the
-following lines to the ``dependency_resolvers_conf.xml`` file in the
-Galaxy ``config`` directory::
-
-    <dependency_resolvers>
-    ...
-      <galaxy_packages base_path="/path/to/local_tool_dependencies" />
-      <galaxy_packages base_path="/path/to/local_tool_dependencies" versionless="true" />
-      ...
-    </dependency_resolvers>
-
-(NB it is recommended to place these *before* the ``<conda ... />``
-resolvers)
-
-(If you're not familiar with dependency resolvers in Galaxy then
-see the documentation at
-https://docs.galaxyproject.org/en/master/admin/dependency_resolvers.html
-for more details.)
+The final step is to make your Galaxy installation aware of the
+location of the reference data, so it can locate them both when the
+tool is run.
 
 The tool locates the reference data via an environment variable called
 ``AMPLICON_ANALYSIS_REF_DATA_PATH``, which needs to set to the parent
@@ -115,7 +77,8 @@ There are various ways to do this, depending on how your Galaxy
 installation is configured:
 
  * **For local instances:** add a line to set it in the
-   ``config/local_env.sh`` file of your Galaxy installation, e.g.::
+   ``config/local_env.sh`` file of your Galaxy installation (you
+   may need to create a new empty file first), e.g.::
 
        export AMPLICON_ANALYSIS_REF_DATA_PATH=/path/to/pipeline/data
 
@@ -131,9 +94,9 @@ installation is configured:
        <tool id="amplicon_analysis_pipeline" destination="amplicon_analysis"/>
 
    (For more about job destinations see the Galaxy documentation at
-   https://galaxyproject.org/admin/config/jobs/#job-destinations)
+   https://docs.galaxyproject.org/en/master/admin/jobs.html#job-destinations)
 
-5. Enable rendering of HTML outputs from pipeline
+4. Enable rendering of HTML outputs from pipeline
 -------------------------------------------------
 
 To ensure that HTML outputs are displayed correctly in Galaxy
@@ -178,6 +141,33 @@ Known problems
    https://github.com/galaxyproject/galaxy/issues/4490 and
    https://github.com/galaxyproject/galaxy/issues/1676
 
+Appendix: installing the dependencies manually
+==============================================
+
+If the tool is installed from the Galaxy toolshed (recommended) then
+the dependencies should be installed automatically and this step can
+be skipped.
+
+Otherwise the ``install_amplicon_analysis_deps.sh`` script can be used
+to fetch and install the dependencies locally, for example::
+
+    install_amplicon_analysis.sh /path/to/local_tool_dependencies
+
+(This is the same script as is used to install dependencies from the
+toolshed.) This can take some time to complete, and when completed will
+have created a directory called ``Amplicon_analysis-1.2.3`` containing
+the dependencies under the specified top level directory.
+
+**NB** The installed dependencies will occupy around 2.6G of disk
+space.
+
+You will need to make sure that the ``bin`` subdirectory of this
+directory is on Galaxy's ``PATH`` at runtime, for the tool to be able
+to access the dependencies - for example by adding a line to the
+``local_env.sh`` file like::
+
+    export PATH=/path/to/local_tool_dependencies/Amplicon_analysis-1.2.3/bin:$PATH
+
 History
 =======
 
@@ -185,7 +175,7 @@ History
 Version    Changes
 ---------- ----------------------------------------------------------------------
 1.2.3.0    Updated to Amplicon_Analysis_Pipeline version 1.2.3; install
-           dependencies from bioconda and via tool_dependencies.xml.
+           dependencies via tool_dependencies.xml.
 1.2.2.0    Updated to Amplicon_Analysis_Pipeline version 1.2.2 (removes
            jackknifed analysis which is not captured by Galaxy tool)
 1.2.1.0    Updated to Amplicon_Analysis_Pipeline version 1.2.1 (adds

--- a/README.rst
+++ b/README.rst
@@ -198,19 +198,16 @@ version:
  - bioawk 1.0
  - fastqc 0.11.3
  - R 3.2.0
-
-Some dependencies are available but with the "wrong" versions:
-
- - spades (need 3.5.0)
- - qiime (need 1.8.0)
- - blast (need 2.2.26)
- - vsearch (need 1.1.3)
+ - spades 3.5.0
+ - qiime 1.8.0
+ - blast-legacy 2.2.26
+ - vsearch 1.1.3
+ - fasta-splitter 0.2.4
+ - rdp_classifier 2.2
 
 The following dependencies are currently unavailable:
 
  - fasta_number (need 02jun2015)
- - fasta-splitter (need 0.2.4)
- - rdp_classifier (need 2.2)
  - microbiomeutil (need r20110519)
 
 (NB usearch 6.1.544 and 8.0.1623 are special cases which must be
@@ -222,6 +219,7 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+1.2.2.1    Update to get dependencies from bioconda
 1.2.2.0    Updated to Amplicon_Analysis_Pipeline version 1.2.2 (removes
            jackknifed analysis which is not captured by Galaxy tool)
 1.2.1.0    Updated to Amplicon_Analysis_Pipeline version 1.2.1 (adds

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -225,6 +225,15 @@ if __name__ == "__main__":
         print "-- set RDP_JAR_PATH: %s" % os.environ["RDP_JAR_PATH"]
     else:
         sys.stderr.write("Missing 'rdp_classifier.jar'\n")
+    # Set up qiime_config file
+    qiime_config_file = os.path.abspath("qiime_config")
+    with open(qiime_config_file,'w') as qiime_config:
+        # Set qiime_scripts_dir
+        qiime_config.write("qiime_scripts_dir\t%s" %
+                           os.path.dirname(
+                               find_executable("single_rarefaction.py")))
+    os.environ["QIIME_CONFIG_FP"] = qiime_config_file
+    print "-- set QIIME_CONFIG_FP: %s" % os.environ["QIIME_CONFIG_FP"]
 
     # Construct the pipeline command
     print "Amplicon analysis: constructing pipeline command"

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -60,9 +60,10 @@ def print_error(message):
     sys.stderr.write("%s\n\n" % ('*'*width))
 
 def clean_up_name(sample):
-    # Remove trailing "_L[0-9]+_001" from Fastq
-    # pair names
-    split_name = sample.split('_')
+    # Remove extensions and trailing "_L[0-9]+_001" from
+    # Fastq pair names
+    sample_name = '.'.join(sample.split('.')[:1])
+    split_name = sample_name.split('_')
     if split_name[-1] == "001":
         split_name = split_name[:-1]
     if split_name[-1].startswith('L'):
@@ -148,10 +149,12 @@ if __name__ == "__main__":
 
     # Link to FASTQs and construct Final_name.txt file
     sample_names = []
+    print "-- making Final_name.txt"
     with open("Final_name.txt",'w') as final_name:
         fastqs = iter(args.fastq_pairs)
         for sample_name,fqr1,fqr2 in zip(fastqs,fastqs,fastqs):
             sample_name = clean_up_name(sample_name)
+            print "   %s" % sample_name
             r1 = "%s_R1_.fastq" % sample_name
             r2 = "%s_R2_.fastq" % sample_name
             os.symlink(fqr1,r1)

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -99,7 +99,9 @@ def list_outputs(filen=None):
 def find_executable(name):
     # Locate executable on PATH
     for p in os.environ['PATH'].split(os.pathsep):
-        exe = os.path.join(p,name)
+        exe = os.path.normpath(
+            os.path.abspath(os.path.join(p,name)))
+        print "Checking %s" % exe
         if os.path.isfile(exe) and os.access(exe,os.X_OK):
             return exe
     return None
@@ -187,8 +189,11 @@ if __name__ == "__main__":
     # 'fasta-splitter'
     fasta_splitter = find_executable("fasta-splitter.pl")
     if fasta_splitter is None:
-        fasta_splitter = os.readlink(
-            find_executable("fasta-splitter"))
+        fasta_splitter = find_executable("fasta-splitter")
+        if os.path.islink(fasta_splitter):
+            fasta_splitter = os.path.join(
+                os.path.dirname(fasta_splitter),
+                os.readlink(fasta_splitter))
     if fasta_splitter:
         os.symlink(fasta_splitter,os.path.join("bin","fasta-splitter.pl"))
         print "-- made symlink to %s" % fasta_splitter

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -99,7 +99,7 @@ def list_outputs(filen=None):
 def find_executable(name):
     # Locate executable on PATH
     for p in os.environ['PATH'].split(os.pathsep):
-        exe = os.path.join(name)
+        exe = os.path.join(p,name)
         if os.path.isfile(exe) and os.access(exe,os.X_OK):
             return exe
     return None
@@ -191,6 +191,7 @@ if __name__ == "__main__":
             find_executable("fasta-splitter"))
     if fasta_splitter:
         os.symlink(vsearch,os.path.join("bin","fasta-splitter.pl"))
+        print "-- made symlink to %s" % fasta_splitter
     else:
         sys.stderr.write("Missing 'fasta-splitter[.pl]'\n")
 

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     # 'fasta-splitter'
     fasta_splitter = find_executable("fasta-splitter.pl")
     if fasta_splitter is None:
-        fasta_splitter = os.path.readlink(
+        fasta_splitter = os.readlink(
             find_executable("fasta-splitter"))
     if fasta_splitter:
         os.symlink(vsearch,os.path.join("bin","fasta-splitter.pl"))

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
         fasta_splitter = os.readlink(
             find_executable("fasta-splitter"))
     if fasta_splitter:
-        os.symlink(vsearch,os.path.join("bin","fasta-splitter.pl"))
+        os.symlink(fasta_splitter,os.path.join("bin","fasta-splitter.pl"))
         print "-- made symlink to %s" % fasta_splitter
     else:
         sys.stderr.write("Missing 'fasta-splitter[.pl]'\n")

--- a/amplicon_analysis_pipeline.py
+++ b/amplicon_analysis_pipeline.py
@@ -101,7 +101,6 @@ def find_executable(name):
     for p in os.environ['PATH'].split(os.pathsep):
         exe = os.path.normpath(
             os.path.abspath(os.path.join(p,name)))
-        print "Checking %s" % exe
         if os.path.isfile(exe) and os.access(exe,os.X_OK):
             return exe
     return None

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -16,6 +16,7 @@
     <requirement type="package" version="2.2">rdp_classifier</requirement>
     <requirement type="package" version="3.2.1">R</requirement>
     <requirement type="package" version="1.1.3">vsearch</requirement>
+    <requirement type="package" version="1.2.22">uclust-qiime</requirement>
     <!-- microbiomeutil not available in bioconda -->
     <requirement type="package" version="2010-04-29">microbiomeutil</requirement>
     <!-- fastq_number not available in bioconda -->

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -1,20 +1,24 @@
-<tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.2.0">
+<tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.2.1">
   <description>analyse 16S rRNA data from Illumina Miseq paired-end reads</description>
   <requirements>
+    <!-- amplicon_analysis_pipeline not available in bioconda -->
     <requirement type="package" version="1.2.2">amplicon_analysis_pipeline</requirement>
+    <requirement type="package" version="2.7">python</requirement>
     <requirement type="package" version="1.11">cutadapt</requirement>
-    <requirement type="package" version="1.33">sickle</requirement>
-    <requirement type="package" version="27-08-2013">bioawk</requirement>
+    <requirement type="package" version="1.33">sickle-trim</requirement>
+    <requirement type="package" version="1.0">bioawk</requirement>
     <requirement type="package" version="2.8.1">pandaseq</requirement>
     <requirement type="package" version="3.5.0">spades</requirement>
     <requirement type="package" version="0.11.3">fastqc</requirement>
     <requirement type="package" version="1.8.0">qiime</requirement>
-    <requirement type="package" version="2.2.26">blast</requirement>
+    <requirement type="package" version="2.2.26">blast-legacy</requirement>
     <requirement type="package" version="0.2.4">fasta-splitter</requirement>
-    <requirement type="package" version="2.2">rdp-classifier</requirement>
+    <requirement type="package" version="2.2">rdp_classifier</requirement>
     <requirement type="package" version="3.2.0">R</requirement>
     <requirement type="package" version="1.1.3">vsearch</requirement>
+    <!-- microbiomeutil not available in bioconda -->
     <requirement type="package" version="2010-04-29">microbiomeutil</requirement>
+    <!-- fastq_number not available in bioconda -->
     <requirement type="package">fasta_number</requirement>
   </requirements>
   <stdio>

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -1,11 +1,10 @@
-<tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.2.1">
+<tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.3.0">
   <description>analyse 16S rRNA data from Illumina Miseq paired-end reads</description>
   <requirements>
     <!-- non-bioconda dependencies -->
-    <requirement type="package" version="1.2.2">amplicon_analysis_pipeline</requirement>
+    <requirement type="package" version="1.2.3">amplicon_analysis_pipeline</requirement>
     <requirement type="package" version="2010-04-29">microbiomeutil-chimeraslayer</requirement>
     <requirement type="package" version="1.2.22">uclust-qiime</requirement>
-    <requirement type="package">fasta_number</requirement>
     <!-- bioconda dependencies -->
     <requirement type="package" version="2.7">python</requirement>
     <requirement type="package" version="1.11">cutadapt</requirement>
@@ -19,6 +18,7 @@
     <requirement type="package" version="0.2.4">fasta-splitter</requirement>
     <requirement type="package" version="2.2">rdp_classifier</requirement>
     <requirement type="package" version="1.1.3">vsearch</requirement>
+    <!-- toolshed dependencies -->
     <requirement type="package" version="3.2.1">R</requirement>
   </requirements>
   <stdio>

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -14,6 +14,7 @@
     <requirement type="package" version="3.5.0">spades</requirement>
     <requirement type="package" version="0.11.3">fastqc</requirement>
     <requirement type="package" version="1.8.0">qiime</requirement>
+    <requirement type="package" version="1.0">libgfortran</requirement>
     <requirement type="package" version="2.2.26">blast-legacy</requirement>
     <requirement type="package" version="0.2.4">fasta-splitter</requirement>
     <requirement type="package" version="2.2">rdp_classifier</requirement>

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -1,8 +1,12 @@
 <tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.2.1">
   <description>analyse 16S rRNA data from Illumina Miseq paired-end reads</description>
   <requirements>
-    <!-- amplicon_analysis_pipeline not available in bioconda -->
+    <!-- non-bioconda dependencies -->
     <requirement type="package" version="1.2.2">amplicon_analysis_pipeline</requirement>
+    <requirement type="package" version="2010-04-29">microbiomeutil-chimeraslayer</requirement>
+    <requirement type="package" version="1.2.22">uclust-qiime</requirement>
+    <requirement type="package">fasta_number</requirement>
+    <!-- bioconda dependencies -->
     <requirement type="package" version="2.7">python</requirement>
     <requirement type="package" version="1.11">cutadapt</requirement>
     <requirement type="package" version="1.33">sickle-trim</requirement>
@@ -14,13 +18,8 @@
     <requirement type="package" version="2.2.26">blast-legacy</requirement>
     <requirement type="package" version="0.2.4">fasta-splitter</requirement>
     <requirement type="package" version="2.2">rdp_classifier</requirement>
-    <requirement type="package" version="3.2.1">R</requirement>
     <requirement type="package" version="1.1.3">vsearch</requirement>
-    <requirement type="package" version="1.2.22">uclust-qiime</requirement>
-    <!-- microbiomeutil not available in bioconda -->
-    <requirement type="package" version="2010-04-29">microbiomeutil</requirement>
-    <!-- fastq_number not available in bioconda -->
-    <requirement type="package">fasta_number</requirement>
+    <requirement type="package" version="3.2.1">R</requirement>
   </requirements>
   <stdio>
     <exit_code range="1:" />

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -1,26 +1,7 @@
 <tool id="amplicon_analysis_pipeline" name="Amplicon Analysis Pipeline" version="1.2.3.0">
   <description>analyse 16S rRNA data from Illumina Miseq paired-end reads</description>
   <requirements>
-    <!-- non-bioconda dependencies -->
     <requirement type="package" version="1.2.3">amplicon_analysis_pipeline</requirement>
-    <requirement type="package" version="2010-04-29">microbiomeutil-chimeraslayer</requirement>
-    <requirement type="package" version="1.2.22">uclust-qiime</requirement>
-    <!-- bioconda dependencies -->
-    <requirement type="package" version="2.7">python</requirement>
-    <requirement type="package" version="1.11">cutadapt</requirement>
-    <requirement type="package" version="1.33">sickle-trim</requirement>
-    <requirement type="package" version="1.0">bioawk</requirement>
-    <requirement type="package" version="2.8.1">pandaseq</requirement>
-    <requirement type="package" version="3.5.0">spades</requirement>
-    <requirement type="package" version="0.11.3">fastqc</requirement>
-    <requirement type="package" version="1.8.0">qiime</requirement>
-    <requirement type="package" version="1.0">libgfortran</requirement>
-    <requirement type="package" version="2.2.26">blast-legacy</requirement>
-    <requirement type="package" version="0.2.4">fasta-splitter</requirement>
-    <requirement type="package" version="2.2">rdp_classifier</requirement>
-    <requirement type="package" version="1.1.3">vsearch</requirement>
-    <!-- toolshed dependencies -->
-    <requirement type="package" version="3.2.1">R</requirement>
   </requirements>
   <stdio>
     <exit_code range="1:" />

--- a/amplicon_analysis_pipeline.xml
+++ b/amplicon_analysis_pipeline.xml
@@ -14,7 +14,7 @@
     <requirement type="package" version="2.2.26">blast-legacy</requirement>
     <requirement type="package" version="0.2.4">fasta-splitter</requirement>
     <requirement type="package" version="2.2">rdp_classifier</requirement>
-    <requirement type="package" version="3.2.0">R</requirement>
+    <requirement type="package" version="3.2.1">R</requirement>
     <requirement type="package" version="1.1.3">vsearch</requirement>
     <!-- microbiomeutil not available in bioconda -->
     <requirement type="package" version="2010-04-29">microbiomeutil</requirement>

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -10,6 +10,7 @@
 	  </action>
 	  <action type="set_environment">
 	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/Amplicon_analysis_pipeline</environment_variable>
+	  </action>
 	</actions>
       </install>
   </package>

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -3,7 +3,7 @@
   <package name="amplicon_analysis_pipeline" version="1.2.3">
       <install version="1.0">
 	<actions>
-	  <action type="download_by_url">https://github.com/MTutino/Amplicon_analysis/archive/v1.2.2.tar.gz</action>
+	  <action type="download_by_url">https://github.com/MTutino/Amplicon_analysis/archive/v1.2.3.tar.gz</action>
 	  <action type="move_file">
 	    <source>Amplicon_analysis_pipeline.sh</source>
 	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <tool_dependency>
-  <package name="amplicon_analysis_pipeline" version="1.2.2">
+  <package name="amplicon_analysis_pipeline" version="1.2.3">
       <install version="1.0">
 	<actions>
 	  <action type="download_by_url">https://github.com/MTutino/Amplicon_analysis/archive/v1.2.2.tar.gz</action>

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<tool_dependency>
+  <package name="amplicon_analysis_pipeline" version="1.2.2">
+      <install version="1.0">
+	<actions>
+	  <action type="download_by_url">https://github.com/MTutino/Amplicon_analysis/archive/v1.2.2.tar.gz</action>
+	  <action type="move_directory_files">
+	    <source>.</source>
+	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
+	  </action>
+	  <action type="set_environment">
+	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/Amplicon_analysis_pipeline</environment_variable>
+	</actions>
+      </install>
+  </package>
+  <package name="R" version="3.2.1">
+    <repository name="package_r_3_2_1" owner="iuc" />
+  </package>
+</tool_dependency>

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -1,80 +1,16 @@
 <?xml version="1.0"?>
 <tool_dependency>
   <package name="amplicon_analysis_pipeline" version="1.2.3">
-      <install version="1.0">
-	<actions>
-	  <action type="download_by_url">https://github.com/MTutino/Amplicon_analysis/archive/v1.2.3.tar.gz</action>
-	  <action type="move_file">
-	    <source>Amplicon_analysis_pipeline.sh</source>
-	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
-	  </action>
-	  <action type="move_file">
-	    <source>FIRST_STEP.sh</source>
-	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
-	  </action>
-	  <action type="move_file">
-	    <source>VSEARCH.sh</source>
-	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
-	  </action>
-	  <action type="move_file">
-	    <source>STAT_ANALYSIS.sh</source>
-	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
-	  </action>
-	  <action type="move_file">
-	    <source>THIRD_STEP.sh</source>
-	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
-	  </action>
-	  <action type="move_directory_files">
-	    <source_directory>uc2otutab</source_directory>
-	    <destination_directory>$INSTALL_DIR/Amplicon_analysis_pipeline/uc2otutab</destination_directory>
-	  </action>
-	  <action type="set_environment">
-	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/Amplicon_analysis_pipeline</environment_variable>
-	  </action>
-	</actions>
-      </install>
-  </package>
-  <!--
-      microbiomeutil provides ChimeraSlayer
-  -->
-  <package name="microbiomeutil-chimeraslayer" version="2010-04-29">
     <install version="1.0">
       <actions>
-	<action type="download_by_url">https://sourceforge.net/projects/microbiomeutil/files/__OLD_VERSIONS/microbiomeutil_2010-04-29.tar.gz</action>
-	<action type="move_directory_files">
-	  <source_directory>ChimeraSlayer</source_directory>
-	  <destination_directory>$INSTALL_DIR/ChimeraSlayer</destination_directory>
+	<action type="download_file">https://raw.githubusercontent.com/pjbriggs/Amplicon_analysis-galaxy/5fe08ecabf682265778d6307fa63a44c768d251c/install_amplicon_analysis.sh</action>
+	<action type="shell_command">
+	  sh ./install_amplicon_analysis.sh $INSTALL_DIR
 	</action>
 	<action type="set_environment">
-	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/ChimeraSlayer</environment_variable>
+	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/Amplicon_analysis-1.2.3/bin</environment_variable>
 	</action>
       </actions>
     </install>
-  </package>
-  <!--
-      uclust required for QIIME/pyNAST
-      License only allows this version to be used with those two packages
-      See:
-      http://drive5.com/uclust/downloads1_2_22q.html
-  -->
-  <package name="uclust-qiime" version="1.2.22">
-    <install version="1.0">
-      <actions>
-	<action type="download_by_url">http://drive5.com/uclust/uclustq1.2.22_i86linux64</action>
-	<action type="move_file" rename_to="uclust">
-	  <source>uclustq1.2.22_i86linux64</source>
-	  <destination>$INSTALL_DIR/bin</destination>
-	</action>
-	<action type="chmod">
-	  <file mode="755">$INSTALL_DIR/bin/uclust</file>
-	</action>
-	<action type="set_environment">
-	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
-	</action>
-      </actions>
-    </install>
-  </package>
-  <package name="R" version="3.2.1">
-    <repository name="package_r_3_2_1" owner="iuc" />
   </package>
 </tool_dependency>

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -4,8 +4,24 @@
       <install version="1.0">
 	<actions>
 	  <action type="download_by_url">https://github.com/MTutino/Amplicon_analysis/archive/v1.2.2.tar.gz</action>
-	  <action type="move_directory_files">
-	    <source>.</source>
+	  <action type="move_file">
+	    <source>Amplicon_analysis_pipeline.sh</source>
+	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
+	  </action>
+	  <action type="move_file">
+	    <source>FIRST_STEP.sh</source>
+	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
+	  </action>
+	  <action type="move_file">
+	    <source>VSEARCH.sh</source>
+	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
+	  </action>
+	  <action type="move_file">
+	    <source>STAT_ANALYSIS.sh</source>
+	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
+	  </action>
+	  <action type="move_file">
+	    <source>THIRD_STEP.sh</source>
 	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
 	  </action>
 	  <action type="set_environment">

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -35,6 +35,23 @@
       </install>
   </package>
   <!--
+      microbiomeutil provides ChimeraSlayer
+  -->
+  <package name="microbiomeutil-chimeraslayer" version="2010-04-29">
+    <install version="1.0">
+      <actions>
+	<action type="download_by_url">https://sourceforge.net/projects/microbiomeutil/files/__OLD_VERSIONS/microbiomeutil_2010-04-29.tar.gz</action>
+	<action type="move_directory_files">
+	  <source_directory>ChimeraSlayer</source_directory>
+	  <destination_directory>$INSTALL_DIR/ChimeraSlayer</destination_directory>
+	</action>
+	<action type="set_environment">
+	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/ChimeraSlayer</environment_variable>
+	</action>
+      </actions>
+    </install>
+  </package>
+  <!--
       uclust required for QIIME/pyNAST
       License only allows this version to be used with those two packages
       See:

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -34,6 +34,29 @@
 	</actions>
       </install>
   </package>
+  <!--
+      uclust required for QIIME/pyNAST
+      License only allows this version to be used with those two packages
+      See:
+      http://drive5.com/uclust/downloads1_2_22q.html
+  -->
+  <package name="uclust-qiime" version="1.2.22">
+    <install version="1.0">
+      <actions>
+	<action type="download_by_url">http://drive5.com/uclust/uclustq1.2.22_i86linux64</action>
+	<action type="move_file" rename_to="uclust">
+	  <source>uclustq1.2.22_i86linux64</source>
+	  <destination>$INSTALL_DIR/bin</destination>
+	</action>
+	<action type="chmod">
+	  <file mode="755">$INSTALL_DIR/bin/uclust</file>
+	</action>
+	<action type="set_environment">
+	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
+	</action>
+      </actions>
+    </install>
+  </package>
   <package name="R" version="3.2.1">
     <repository name="package_r_3_2_1" owner="iuc" />
   </package>

--- a/tool_dependencies.xml
+++ b/tool_dependencies.xml
@@ -24,6 +24,10 @@
 	    <source>THIRD_STEP.sh</source>
 	    <destination>$INSTALL_DIR/Amplicon_analysis_pipeline</destination>
 	  </action>
+	  <action type="move_directory_files">
+	    <source_directory>uc2otutab</source_directory>
+	    <destination_directory>$INSTALL_DIR/Amplicon_analysis_pipeline/uc2otutab</destination_directory>
+	  </action>
 	  <action type="set_environment">
 	    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/Amplicon_analysis_pipeline</environment_variable>
 	  </action>


### PR DESCRIPTION
PR which aims to move the acquisition of the tool dependencies to `conda`.

**Update** for various reasons it has not been possible to acquire all the dependencies for the tool from `conda` (for example there is an incompatibility between `qiime` 1.8.0 and `R` 3.2.1 when this approach is used).

So instead the dependencies are now installed via the installer script, which uses `conda` but is invoked via the `tool_dependencies.xml` file.